### PR TITLE
fix(codelldb): use vscode extension from master

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -93,6 +93,22 @@
         "type": "github"
       }
     },
+    "masterpkgs": {
+      "locked": {
+        "lastModified": 1697112781,
+        "narHash": "sha256-97JRQh6eeGbxY46P+FMH8krowXQE3IV2WynE7MkW89Y=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "ea05d48289b457fbd75e3b9ac43dda5212f3a7c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "master",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nix-direnv": {
       "inputs": {
         "flake-utils": "flake-utils",
@@ -244,6 +260,7 @@
         "flake-compat": "flake-compat",
         "home-manager": "home-manager",
         "homeage": "homeage",
+        "masterpkgs": "masterpkgs",
         "nix-direnv": "nix-direnv",
         "nix-formatter-pack": "nix-formatter-pack",
         "nixd": "nixd",

--- a/flake.nix
+++ b/flake.nix
@@ -3,8 +3,10 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
-
     unstablepkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+    /* Warning: packages from this repo are subject to change rapidly!. */
+    masterpkgs.url = "github:NixOS/nixpkgs/master";
 
     home-manager.url = "github:nix-community/home-manager/release-23.05";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
@@ -36,6 +38,7 @@
     , homeage
     , nixd
     , nix-direnv
+    , masterpkgs
     , ...
     }:
     let
@@ -68,17 +71,25 @@
         ];
       };
 
+      master = import masterpkgs {
+        inherit system;
+        config = {
+          allowUnfree = true;
+          allowUnfreePredicate = _: true;
+        };
+      };
+
       helpers = import ./lib { inherit home-manager nixpkgs homeage; };
     in
     {
       homeConfigurations."massi@elendil" = helpers.mkHome {
-        inherit pkgs unstable stateVersion;
+        inherit pkgs unstable stateVersion master;
         username = "massi";
         extraModules = [ ./home/elendil ];
       };
 
       homeConfigurations."massi@coravandil" = helpers.mkHome {
-        inherit pkgs unstable stateVersion;
+        inherit pkgs unstable stateVersion master;
         username = "massi";
         extraModules = [ ./home/coravandil ];
       };

--- a/home/elendil/default.nix
+++ b/home/elendil/default.nix
@@ -106,7 +106,7 @@ in
 
       font = {
         package = unstable.nerdfonts;
-        name = "JetBrainsMono Nerd Font";
+        name = "CaskaydiaCove Nerd Font";
         size = 11;
       };
 

--- a/home/elendil/default.nix
+++ b/home/elendil/default.nix
@@ -146,7 +146,7 @@ in
 
       unstable-packages = with unstable; [
         obsidian
-        chromium
+        google-chrome-dev
         spotify
         just
       ];

--- a/home/modules/neovim/default.nix
+++ b/home/modules/neovim/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, unstable, master, ... }:
+{ config, lib, pkgs, unstable, master, username, ... }:
 let
   cfg = config.my-modules.neovim;
   inherit (lib) mkEnableOption mkIf;
@@ -164,6 +164,7 @@ in
             vsCodeJsDebug = "${vscode-js-debug}/vscode-js-debug",
             nodePath = "${pkgs.nodejs}/bin/node",
             rustDebugger = "${master.vscode-extensions.vadimcn.vscode-lldb}",
+            rustWrapper = "/home/${username}/${nvimHome}/lldb-wrapper.sh",
           }
         '';
 
@@ -188,6 +189,15 @@ in
         "${plugins}/hardtime.lua".source = ./files/plugins/hardtime.lua;
         "${plugins}/codeium.lua".source = ./files/plugins/codeium.lua;
         "${plugins}/rust.lua".source = ./files/plugins/rust.lua;
+
+        /* For reasons I still do not know, I have to create a wrapper for the codelldb extension to work, probably it's the env */
+        "${nvimHome}/lldb-wrapper.sh" = {
+          executable = true;
+          text = ''
+            #!/usr/bin/env bash
+            exec ${master.vscode-extensions.vadimcn.vscode-lldb}/share/vscode/extensions/vadimcn.vscode-lldb/adapter/codelldb "$@"
+          '';
+        };
       };
 
     home.sessionVariables = mkIf cfg.defaultEditor {

--- a/home/modules/neovim/default.nix
+++ b/home/modules/neovim/default.nix
@@ -1,4 +1,4 @@
-{ config, lib, pkgs, unstable, ... }:
+{ config, lib, pkgs, unstable, master, ... }:
 let
   cfg = config.my-modules.neovim;
   inherit (lib) mkEnableOption mkIf;
@@ -122,7 +122,7 @@ in
 
             /* Debuggers */
             vscode-js-debug /* debugger for javascript */
-            vscode-extensions.vadimcn.vscode-lldb /* debugger for rust */
+            master.vscode-extensions.vadimcn.vscode-lldb /* debugger for rust */
 
             /* Test runners */
             cargo-nextest /* test runner for rust */
@@ -163,7 +163,7 @@ in
             codeiumLs = "${codeium-ls}/bin/codeium-ls_server_linux_x64",
             vsCodeJsDebug = "${vscode-js-debug}/vscode-js-debug",
             nodePath = "${pkgs.nodejs}/bin/node",
-            rustDebugger = "${pkgs.vscode-extensions.vadimcn.vscode-lldb}",
+            rustDebugger = "${master.vscode-extensions.vadimcn.vscode-lldb}",
           }
         '';
 

--- a/home/modules/neovim/files/plugins/dap.lua
+++ b/home/modules/neovim/files/plugins/dap.lua
@@ -162,10 +162,10 @@ return {
       dap.adapters.codelldb = {
         type = "server",
         host = "127.0.0.1",
-        port = 3500,
+        port = "${port}",
         executable = {
           command = codelldb_path,
-          args = { "--port", "3500", "--liblldb", liblldb_path },
+          args = { "--port", "${port}", "--liblldb", liblldb_path },
         },
       }
     end,

--- a/home/modules/neovim/files/plugins/dap.lua
+++ b/home/modules/neovim/files/plugins/dap.lua
@@ -147,7 +147,6 @@ return {
       vim.api.nvim_set_hl(0, "DapStoppedLine", { default = true, link = "Visual" })
       local extension_path = nix.rustDebugger .. "/share/vscode/extensions/vadimcn.vscode-lldb"
 
-      local codelldb_path = extension_path .. "/adapter/codelldb"
       local liblldb_path = extension_path .. "/lldb/lib/liblldb.so"
       local dap = require("dap")
 
@@ -164,7 +163,7 @@ return {
         host = "127.0.0.1",
         port = "${port}",
         executable = {
-          command = codelldb_path,
+          command = nix.rustWrapper,
           args = { "--port", "${port}", "--liblldb", liblldb_path },
         },
       }

--- a/home/modules/neovim/files/plugins/rust.lua
+++ b/home/modules/neovim/files/plugins/rust.lua
@@ -10,7 +10,6 @@ return {
       local nix = require("util.nix")
       local extension_path = nix.rustDebugger .. "/share/vscode/extensions/vadimcn.vscode-lldb"
 
-      local codelldb_path = extension_path .. "/adapter/codelldb"
       local liblldb_path = extension_path .. "/lldb/lib/liblldb.so"
 
       return {
@@ -18,7 +17,7 @@ return {
           executor = require("rust-tools.executors.toggleterm"),
         },
         dap = {
-          adapter = require("rust-tools.dap").get_codelldb_adapter(codelldb_path, liblldb_path),
+          adapter = require("rust-tools.dap").get_codelldb_adapter(nix.rustWrapper, liblldb_path),
         },
       }
     end,

--- a/lib/default.nix
+++ b/lib/default.nix
@@ -4,9 +4,9 @@
 , ...
 }: {
   mkHome =
-    { pkgs, unstable, stateVersion, username, extraModules ? [ ] }: home-manager.lib.homeManagerConfiguration {
+    { pkgs, unstable, master, stateVersion, username, extraModules ? [ ] }: home-manager.lib.homeManagerConfiguration {
       inherit pkgs;
-      extraSpecialArgs = { inherit unstable stateVersion username; };
+      extraSpecialArgs = { inherit unstable master stateVersion username; };
 
       modules = [
         homeage.homeManagerModules.homeage

--- a/system/elendil/configuration.nix
+++ b/system/elendil/configuration.nix
@@ -19,6 +19,16 @@ in
   boot.loader.systemd-boot.enable = true;
   boot.loader.efi.canTouchEfiVariables = true;
 
+  # Enable OpenGL
+  hardware.opengl = {
+    enable = true;
+    extraPackages = with pkgs; [
+      intel-media-driver
+      vaapiVdpau
+      libvdpau-va-gl
+    ];
+  };
+
   # Basic Nix configuration
   nix = {
     gc.automatic = true;

--- a/system/elendil/configuration.nix
+++ b/system/elendil/configuration.nix
@@ -62,15 +62,15 @@ in
   # Select internationalisation properties.
   i18n.defaultLocale = "en_US.UTF-8";
   i18n.extraLocaleSettings = {
-    LC_ADDRESS = "fr_FR.UTF-8";
-    LC_IDENTIFICATION = "fr_FR.UTF-8";
-    LC_MEASUREMENT = "fr_FR.UTF-8";
-    LC_MONETARY = "fr_FR.UTF-8";
-    LC_NAME = "fr_FR.UTF-8";
-    LC_NUMERIC = "fr_FR.UTF-8";
-    LC_PAPER = "fr_FR.UTF-8";
-    LC_TELEPHONE = "fr_FR.UTF-8";
-    LC_TIME = "fr_FR.UTF-8";
+    LC_ADDRESS = "it_IT.UTF-8";
+    LC_IDENTIFICATION = "it_IT.UTF-8";
+    LC_MEASUREMENT = "it_IT.UTF-8";
+    LC_MONETARY = "it_IT.UTF-8";
+    LC_NAME = "it_IT.UTF-8";
+    LC_NUMERIC = "it_IT.UTF-8";
+    LC_PAPER = "it_IT.UTF-8";
+    LC_TELEPHONE = "it_IT.UTF-8";
+    LC_TIME = "it_IT.UTF-8";
   };
 
   # Enable the X11 windowing system.


### PR DESCRIPTION
Apparently, a fix has been provided here https://github.com/NixOS/nixpkgs/issues/239403 for the missing Python extension error, but it doesn't work for me right
  now.. still committing this