### PR TITLE
Replace deprecated nodePackages.prettier with prettier

### DIFF
--- a/home/modules/neovim/languages/default.nix
+++ b/home/modules/neovim/languages/default.nix
@@ -36,7 +36,7 @@ let
     gofumpt
     deadnix
     nixpkgs-fmt
-    nodePackages.prettier
+    prettier
     (stylua.override { features = [ "lua54" "luau" ]; })
     yamlfmt
     typstyle


### PR DESCRIPTION
## Summary
- Replaced deprecated `nodePackages.prettier` with `prettier` in neovim language configuration