### PR TITLE
refactor: rename my-modules namespace to massix in home-manager modules

### DIFF
--- a/home/aiwendil/default.nix
+++ b/home/aiwendil/default.nix
@@ -19,7 +19,7 @@ let
   '';
 in
 {
-  my-modules = {
+  massix = {
     fonts = {
       enable = true;
       typefonts = false;

--- a/home/elendil/default.nix
+++ b/home/elendil/default.nix
@@ -26,7 +26,7 @@ in
 {
   imports = [ ];
 
-  my-modules = {
+  massix = {
     firefox = {
       enable = true;
       enableGnomeExtensions = true;

--- a/home/modules/devops.nix
+++ b/home/modules/devops.nix
@@ -5,7 +5,7 @@ let
   yamlGenerator = lib.generators.toYAML { };
   iniGenerator = lib.generators.toINI { };
 
-  cfg = config.my-modules.devops;
+  cfg = config.massix.devops;
 
   k9sThemes = stdenvNoCC.mkDerivation {
     pname = "catppuccin-k9s-themes";
@@ -29,7 +29,7 @@ let
   };
 in
 {
-  options.my-modules.devops = {
+  options.massix.devops = {
     enable = mkEnableOption "devops module";
     terraform = {
       enable = mkEnableOption "terraform";
@@ -121,7 +121,7 @@ in
       kubernetesPackages ++
       vaultPackages;
 
-    my-modules.fish.configuration.extraShellAbbrs =
+    massix.fish.configuration.extraShellAbbrs =
       let
         orEmpty = bool: attrs: if bool then attrs else { };
         kubernetesAbbrs =
@@ -161,7 +161,7 @@ in
       in
       kubernetesAbbrs // tanzuAbbrs // k9sAbbrs // terraformAbbrs // ansibleAbbrs;
 
-    my-modules.fish.configuration.extraShellAliases = mkIf cfg.kubernetes.colored {
+    massix.fish.configuration.extraShellAliases = mkIf cfg.kubernetes.colored {
       kubectl = "kubecolor";
     };
 

--- a/home/modules/firefox.nix
+++ b/home/modules/firefox.nix
@@ -6,7 +6,7 @@
 let
   inherit (pkgs) stdenv;
   inherit (lib) mkEnableOption mkOption mkIf literalExample;
-  cfg = config.my-modules.firefox;
+  cfg = config.massix.firefox;
   mkEngine = template: alias: {
     urls = [{ inherit template; }];
     definedAliases = [ alias ];
@@ -20,7 +20,7 @@ let
   ];
 in
 {
-  options.my-modules.firefox = with lib.types; {
+  options.massix.firefox = with lib.types; {
     enable = mkEnableOption "Custom Firefox setup";
     enableGnomeExtensions = mkEnableOption "enable GNOME extension";
     extraExtensions = mkOption {

--- a/home/modules/fish.nix
+++ b/home/modules/fish.nix
@@ -1,10 +1,10 @@
 { config, lib, pkgs, ... }:
 let
-  cfg = config.my-modules.fish;
+  cfg = config.massix.fish;
   inherit (lib) mkEnableOption mkOption mkIf types concatMapStrings;
 in
 {
-  options.my-modules.fish = {
+  options.massix.fish = {
     enable = mkEnableOption "Enable fish handling";
 
     configuration.extraPaths = mkOption {

--- a/home/modules/fonts.nix
+++ b/home/modules/fonts.nix
@@ -1,6 +1,6 @@
 { config, pkgs, lib, ... }:
 let
-  cfg = config.my-modules.fonts;
+  cfg = config.massix.fonts;
   inherit (lib) mkEnableOption mkIf mkOption types;
   nerdfonts-symbols = pkgs.stdenvNoCC.mkDerivation {
     pname = "symbolsonly-nerdfont";
@@ -25,7 +25,7 @@ let
   };
 in
 {
-  options.my-modules.fonts = {
+  options.massix.fonts = {
     enable = mkEnableOption "Enable fonts handling";
     typefonts = mkEnableOption "install typeface fonts" // { default = true; };
     monospace = mkEnableOption "install monospace fonts" // { default = true; };

--- a/home/modules/ghostty.nix
+++ b/home/modules/ghostty.nix
@@ -4,7 +4,7 @@
 , ...
 }:
 let
-  cfg = config.my-modules.ghostty;
+  cfg = config.massix.ghostty;
   inherit (lib) types mkOption mkIf mkEnableOption;
   # Default values which are valid on both MacOS and GNU/Linux
   # (MacOS options are simply ignored when on GNU/Linux)
@@ -42,7 +42,7 @@ let
   };
 in
 {
-  options.my-modules.ghostty = {
+  options.massix.ghostty = {
     enable = mkEnableOption "enable ghostty";
     package = mkOption {
       type = types.package;

--- a/home/modules/git.nix
+++ b/home/modules/git.nix
@@ -1,10 +1,10 @@
 { config, lib, pkgs, ... }:
 let
-  cfg = config.my-modules.git;
+  cfg = config.massix.git;
   inherit (lib) mkEnableOption mkOption mkIf;
 in
 {
-  options.my-modules.git = {
+  options.massix.git = {
     enable = mkEnableOption "Activate Git module";
     userName = mkOption {
       type = lib.types.str;
@@ -74,7 +74,7 @@ in
       ];
     };
 
-    my-modules.fish.configuration.extraShellAbbrs = mkIf config.my-modules.fish.enable {
+    massix.fish.configuration.extraShellAbbrs = mkIf config.massix.fish.enable {
       g = "git";
       gco = "git checkout";
       gcl = "git clone";

--- a/home/modules/neovim/default.nix
+++ b/home/modules/neovim/default.nix
@@ -4,7 +4,7 @@
 , ...
 }:
 let
-  cfg = config.my-modules.neovim;
+  cfg = config.massix.neovim;
   inherit (lib) mkEnableOption mkPackageOption mkIf strings;
   inherit (lib.generators) toJSON;
   inherit (config.lib.file) mkOutOfStoreSymlink;
@@ -61,7 +61,7 @@ in
 {
   imports = [ ./languages ];
 
-  options.my-modules.neovim = {
+  options.massix.neovim = {
     enable = mkEnableOption "Enable neovim handling";
     defaultEditor = mkEnableOption "Use nvim as default editor";
     configuration = {

--- a/home/modules/opencode/default.nix
+++ b/home/modules/opencode/default.nix
@@ -1,6 +1,6 @@
 { config, lib, pkgs, ... }:
 let
-  cfg = config.my-modules.opencode;
+  cfg = config.massix.opencode;
   inherit (lib) mkEnableOption mkPackageOption mkIf mkOption types;
 
   # Discover agents from agents/ directory by scanning for .md files
@@ -13,7 +13,7 @@ let
     map (removeSuffix ".md") agentFiles;
 in
 {
-  options.my-modules.opencode = {
+  options.massix.opencode = {
     enable = mkEnableOption "Enable opencode configuration";
 
     package = mkPackageOption pkgs "opencode" {

--- a/home/modules/zellij/default.nix
+++ b/home/modules/zellij/default.nix
@@ -1,6 +1,6 @@
 { pkgs, lib, config, ... }:
 let
-  cfg = config.my-modules.zellij;
+  cfg = config.massix.zellij;
   inherit (pkgs) stdenvNoCC;
   inherit (lib) mkEnableOption mkOption types mkIf;
   boolToStr = bool: if bool then "true" else "false";
@@ -26,7 +26,7 @@ let
   configDir = ".config/zellij";
 in
 {
-  options.my-modules.zellij = {
+  options.massix.zellij = {
     enable = mkEnableOption "Activate Zellij module";
 
     configuration = {
@@ -54,7 +54,7 @@ in
       ZELLIJ_AUTO_EXIT = boolToStr cfg.configuration.autoExit;
     };
 
-    my-modules.fish.configuration.extraShellAbbrs = mkIf config.my-modules.fish.enable {
+    massix.fish.configuration.extraShellAbbrs = mkIf config.massix.fish.enable {
       zj = "zellij";
       zjl = "zellij ls";
       zja = "zellij attach";

--- a/home/work-darwin/default.nix
+++ b/home/work-darwin/default.nix
@@ -118,7 +118,7 @@ let
     };
 in
 {
-  my-modules = {
+  massix = {
     firefox = {
       enable = true;
       extraExtensions = with pkgs.nur.repos.rycee.firefox-addons; [


### PR DESCRIPTION
## Summary

Rename the home-manager module namespace from `my-modules` to `massix` across all configuration files.

- 12 files modified
- 25 occurrences renamed
- No functional changes, purely a naming refactor