### PR TITLE
System Update

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -104,11 +104,11 @@
         "zon2nix": "zon2nix"
       },
       "locked": {
-        "lastModified": 1780714066,
-        "narHash": "sha256-7QzhXvYKdkuEPFBv7Bs3WntNCbnoyKxOWN2YlDv4ErU=",
+        "lastModified": 1781644854,
+        "narHash": "sha256-eQAC1raaet8U4NbVrLzhkspI39Jz79uteK4eTv6wc0U=",
         "owner": "ghostty-org",
         "repo": "ghostty",
-        "rev": "f146db5535a154baa74806589f12d7e27daccbbe",
+        "rev": "e8e7fea103ab8bff5384673a60e04b59939738dd",
         "type": "github"
       },
       "original": {
@@ -145,11 +145,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780679734,
-        "narHash": "sha256-KmRNvpNOb7QEORa06bVgjW9kITcx0VhsI7w0vhmZyD8=",
+        "lastModified": 1781667738,
+        "narHash": "sha256-OxrwHpsWf+QGbos1LMDGAcv7sjBGshcw/43th6waeYI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "b2b7db486e06e098711dc291bb25db82850e1d16",
+        "rev": "7664e05e2413d5e2b8c54a884eb8ea0f8a504fc2",
         "type": "github"
       },
       "original": {
@@ -188,11 +188,11 @@
         "treefmt-nix": "treefmt-nix"
       },
       "locked": {
-        "lastModified": 1780275711,
-        "narHash": "sha256-B30XhPvFxPO6rjOJf25O/utHedn52K0iLWxkAGOhTwo=",
+        "lastModified": 1781526262,
+        "narHash": "sha256-YeEf9+Gam3FnqsGc9UOuUa9sCVGy+7FTLL8uayhIG9g=",
         "owner": "nix-community",
         "repo": "nix-direnv",
-        "rev": "e6e7b3537c3c08650c5bfb3de480118ed62e5de5",
+        "rev": "752661855d227e6b2e98413e1bba2afea99ba46d",
         "type": "github"
       },
       "original": {
@@ -206,11 +206,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1780310866,
-        "narHash": "sha256-fPBRVf6A5xlACYcOI59shGrjURuvwu0lRsDoSCEXt/I=",
+        "lastModified": 1781622756,
+        "narHash": "sha256-JrPh4M6S7aPsEE9tOENuZrxC6o2szSLlK+t4+nLke9s=",
         "owner": "NixOS",
         "repo": "nixos-hardware",
-        "rev": "4ed851c979641e28597a05086332d75cdc9e395f",
+        "rev": "08018c72174a4df5657f8d94178ac69fb9c243e5",
         "type": "github"
       },
       "original": {
@@ -234,11 +234,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1780243769,
-        "narHash": "sha256-x5UQuRsH3MqI0U9afaXSNqzTPSeZlRLvFAav2Ux1pNw=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "331800de5053fcebacf6813adb5db9c9dca22a0c",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {
@@ -256,11 +256,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1780720872,
-        "narHash": "sha256-VQBve+3mTLfCQYo7O8+ewNP1hVLoOfrw1SIV/DF953I=",
+        "lastModified": 1781681142,
+        "narHash": "sha256-rgUf8s5vYZ9qlDtChynqK82teZluh/yC1DlraAglYJg=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "1cef25a6b61a5ae03df46df51e138c6597f3763f",
+        "rev": "6b73b91fd3e70d88a8eea31b4d942f3d1568dba5",
         "type": "github"
       },
       "original": {
@@ -297,11 +297,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775771885,
-        "narHash": "sha256-TP7e1+K6CXlpin2bxF97rwLASJXrXZDdZNKmkj1flM0=",
+        "lastModified": 1780972251,
+        "narHash": "sha256-PwHYPpfLP+WjSwj765zJ1N0Xp4ET3+8vRqxJ031ua3M=",
         "owner": "thomashoneyman",
         "repo": "purescript-overlay",
-        "rev": "0aaa4c2124622bd7d2f58c5758037f97c580ee73",
+        "rev": "1cf88ab9d83596db0e0c0d304a16809c410e2917",
         "type": "github"
       },
       "original": {
@@ -363,11 +363,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "lastModified": 1780220602,
+        "narHash": "sha256-eynAfOmbmxJnkp7YewvCEbShNnnYJ9gLLqkzsYtBPeM=",
         "owner": "numtide",
         "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "rev": "db947814a175b7ca6ded66e21383d938df01c227",
         "type": "github"
       },
       "original": {

--- a/home/modules/devops.nix
+++ b/home/modules/devops.nix
@@ -92,7 +92,9 @@ in
         ansiblePackages = orEmpty cfg.ansible.enable [ ansible ];
         kubernetesPackages = orEmpty cfg.kubernetes.enable [
           kubectl
-          kubernetes-helm
+          # doCheck disabled: helm 4.2.0 moved test files to pkg/cmd/ but the
+          # darwin preCheck still patches the old cmd/helm/ paths (nixpkgs#532255).
+          (kubernetes-helm.overrideAttrs (_: { doCheck = false; }))
           fluxcd
           velero
           kustomize

--- a/pkgs/kernel/default.nix
+++ b/pkgs/kernel/default.nix
@@ -35,9 +35,14 @@ pkgs.buildLinux {
     NET_SCH_DEFAULT = yes;
     DEFAULT_FQ_CODEL = yes;
 
-    # Preempt (low-latency)
+    # Preempt (low-latency). The Preemption Model is a Kconfig "choice", so
+    # exactly one member may be set to yes or generate-config.pl aborts with
+    # "conflicting answers!". nixpkgs common-config enables PREEMPT_LAZY for
+    # kernels >= 6.18, so we must disable it here to leave PREEMPT as the sole
+    # selected member.
     PREEMPT = lib.mkOverride 60 yes;
     PREEMPT_VOLUNTARY = lib.mkOverride 60 no;
+    PREEMPT_LAZY = lib.mkOverride 60 no;
 
     # Preemptible tree-based hierarchical RCU
     TREE_RCU = yes;


### PR DESCRIPTION
- Update flake.lock

## Build fixes required by this nixpkgs bump

The updated nixpkgs surfaced two build regressions that are fixed in this branch:

### Kernel: `make config` "conflicting answers!" (`b3d70db`)
The new nixpkgs `common-config.nix` enables `PREEMPT_LAZY` for kernels >= 6.18.
The Preemption Model is a Kconfig `choice`, so our custom Surface/Zen kernel
ended up with two selected members (`PREEMPT` + `PREEMPT_LAZY`). The newer
`generate-config.pl` aborts such choices with `conflicting answers!`, which
cascades into the `Error in reading or end of file.` failure
([nixpkgs#59914](https://github.com/NixOS/nixpkgs/issues/59914)).
Fix: pin `PREEMPT_LAZY = no` in `pkgs/kernel/default.nix` so `PREEMPT` is the
sole selected member. Verified by building the kernel `configfile` derivation
clean in a linux/amd64 container.

### devops: `kubernetes-helm` fails on macOS (`87b0bba`)
Helm 4.2.0 relocated its test files from `cmd/helm/` to `pkg/cmd/`, but the
darwin-only `preCheck` in nixpkgs still patches the old paths, failing
`checkPhase` on macOS
([nixpkgs#532255](https://github.com/NixOS/nixpkgs/issues/532255)).
Fix: `kubernetes-helm.overrideAttrs (_: { doCheck = false; })` in the shared
`home/modules/devops.nix` (applies to both hosts; harmless on linux). Verified
by building helm clean on aarch64-darwin.