### PR TITLE
fix(kernel): add linux-surface dirtyfrag security patches (arch-6.19.8-3)

### DIFF
--- a/pkgs/kernel/default.nix
+++ b/pkgs/kernel/default.nix
@@ -8,8 +8,8 @@ let
   linuxSurface = fetchFromGitHub {
     repo = "linux-surface";
     owner = "linux-surface";
-    rev = "arch-${kernelVersion}-1";
-    hash = "sha256-7kP0Ct5JJkLeSWW5HjeeDgg9BEOnJTbGs/oifKCbRwE=";
+    rev = "arch-${kernelVersion}-3";
+    hash = "sha256-AV+J1iKpA4PEsX9oVUTGlzGerTWTermia3aJSZxuu/w=";
   };
 
   linuxZen = fetchFromGitHub {
@@ -199,5 +199,13 @@ pkgs.buildLinux {
       "0014-amd-gpio"
       "0015-rtc"
       "0016-hid-surface"
+      "0017-dirtyfrag-xfrm-esp-avoid-in-place-decrypt-on-shared-skb-frags"
+      "0018-dirtyfrag-rxrpc-Fix-potential-UAF-after-skb_unshare-failure"
+      "0019-dirtyfrag-rxrpc-Fix-rxrpc_input_call_event-to-only-unshare-DAT"
+      "0020-dirtyfrag-rxrpc-Fix-use-of-wrong-skb-when-comparing-queued-RES"
+      "0021-dirtyfrag-rxrpc-only-handle-RESPONSE-during-service-challenge"
+      "0022-dirtyfrag-rxrpc-Fix-conn-level-packet-handling-to-unshare-RESP"
+      "0023-dirtyfrag-rxrpc-Fix-re-decryption-of-RESPONSE-packets"
+      "0024-dirtyfrag-rxrpc-Also-unshare-DATA-RESPONSE-packets-when-paged-"
     ];
 }


### PR DESCRIPTION
## Summary

Bumps the linux-surface pin from `arch-6.19.8-1` → `arch-6.19.8-3`, pulling in 8 new upstream-backported networking **security** patches (cherry-picked, `Cc: stable`):

- `0017` — xfrm/esp: avoid in-place decrypt on shared skb frags ("dirtyfrag")
- `0018`–`0024` — rxrpc use-after-free / RESPONSE packet-handling fixes

The 16 existing patches (`0001`–`0016`) are byte-identical between `arch-6.19.8-1` and `-3`, so this is purely additive.

## Version check

- **zen-kernel**: still pinned `v6.19.8-zen1`. The 6.19 series has advanced to `v6.19.14-zen1` (and a `7.0.x` series now exists), but we intentionally stay on the base linux-surface validated against.
- **linux-surface**: arch tags for 6.19 are only `-1`/`-2`/`-3`, all on base `6.19.8`. No `arch-7.x` tag / `patches/7.0` dir exists yet → major version stays aligned at **6.19**.

## Verification

- `nix flake check --all-systems` passes locally (eval only — Darwin host can't compile the x86_64-linux kernel).
- The real patch-apply + compile test runs here in **CI**.